### PR TITLE
Fast Refresh requirements clarifcation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The `@wordpress/scripts` package provides all kinds of options that provide ways
 
 ## Fast Refresh
 
-In order to use `--hot` mode, you will need the latest version of Gutenberg installs and have the `SCRIPT_DEBUG` constant set to `true` in the `wp-config.php` file of your development environment.
+In order to use `--hot` mode, you will need WordPress 6.6 or higher or the latest version of Gutenberg installed and have the `SCRIPT_DEBUG` constant set to `true` in the `wp-config.php` file of your development environment.
 
 ### Custom development urls
 


### PR DESCRIPTION
Technically, React Refresh is supported in core from WordPress 6.0:

https://github.com/WordPress/wordpress-develop/blob/d667f6fde9527b85f13724d1958c3fb6897e9d5c/src/wp-includes/script-loader.php#L226-L254

However, in WordPress 6.6 the way JSX is handled has changed, so it's better to promote that version where we know everything works seamlessly with the latest version of WP Scripts.